### PR TITLE
Make favicon work in Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<DOCTYPE! html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Tea Time</title>


### PR DESCRIPTION
I'm not sure why it wasn't throwing other browsers, but you had the "!" after the `DOCTYPE` instead of before it.